### PR TITLE
Make flue obey limit parameter for search endpoint (bug 997793)

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,23 +12,24 @@ import defaults
 
 
 LATENCY = 0
-PER_PAGE = 5
+PER_PAGE = 25
 Response.default_mimetype = 'application/json'
 
 app = Flask('Flue')
 
 
-def _paginated(field, generator, result_count=25):
-    page = int(request.args.get('offset', 0)) / PER_PAGE
-    if page * PER_PAGE > result_count:
+def _paginated(field, generator, result_count=42):
+    per_page = int(request.args.get('limit', PER_PAGE))
+    page = int(request.args.get('offset', 0)) / per_page
+    if page * per_page > result_count:
         items = []
     else:
         items = [gen for i, gen in
-                 zip(xrange(min(10, result_count - page * PER_PAGE)),
+                 zip(xrange(min(per_page, result_count - page * per_page)),
                      generator())]
 
     next_page = None
-    if (page + 1) * PER_PAGE <= result_count:
+    if (page + 1) * per_page <= result_count:
         next_page = request.url
         next_page = next_page[len(request.base_url) -
                               len(request.path + request.script_root):]
@@ -41,15 +42,15 @@ def _paginated(field, generator, result_count=25):
             next_page = next_page[:next_page.index('?')]
         else:
             next_page_qs = {}
-        next_page_qs['offset'] = (page + 1) * PER_PAGE
-        next_page_qs['limit'] = PER_PAGE
+        next_page_qs['offset'] = (page + 1) * per_page
+        next_page_qs['limit'] = per_page
         next_page = next_page + '?' + urllib.urlencode(next_page_qs)
 
     return {
         field: items,
         'meta': {
-            'limit': PER_PAGE,
-            'offset': PER_PAGE * page,
+            'limit': per_page,
+            'offset': per_page * page,
             'next': next_page,
             'total_count': result_count,
         },

--- a/main.py
+++ b/main.py
@@ -98,21 +98,23 @@ def installed():
             i += 1
 
     query = request.args.get('q')
-    data = app._paginated('objects', gen, 0 if query == 'empty' else 25)
+    data = app._paginated('objects', gen, 0 if query == 'empty' else 42)
     return data
 
 
 @app.route('/api/v1/fireplace/search/', endpoint='search-fireplace')
 @app.route('/api/v1/apps/search/')
 def search():
+    offset = int(request.args.get('offset', 0))
     def gen():
         i = 0
         while 1:
-            yield defaults.app('Result', 'sr%d' % i)
+            nb = i + 1 + offset
+            yield defaults.app('Result %d' % nb, 'sr%d' % nb)
             i += 1
 
     query = request.args.get('q')
-    data = app._paginated('objects', gen, 0 if query == 'empty' else 25)
+    data = app._paginated('objects', gen, 0 if query == 'empty' else 42)
     return data
 
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=997793

This also increase the number of results to 25 (and the total result count to 42 to have a higher count) to match zamboni's default behavior. This break fireplace tests, but will be fixed once mozilla/fireplace#441 is merged.
