### PR TITLE
fix bash command Markdown in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ a ```time.sleep(X)``` into the view in ```main.py```.
 Note that you must be added to the Marketplace Stackato group. File a bug with
 ops (e.g., bugzilla.mozilla.org/show_bug.cgi?id=895478) to gain access.
 To deploy an update to the Marketplace mock API that is running on
-```https://flue.paas.allizom.org/```:
+__https://flue.paas.allizom.org/__:
 
 ```bash
 stackato group marketplace


### PR DESCRIPTION
GitHub Markdown is weird

## before
<img width="783" alt="screenshot 2015-08-12 14 45 36" src="https://cloud.githubusercontent.com/assets/203725/9237621/da7eb172-4100-11e5-8f76-6684653ed0ca.png">

## after
<img width="911" alt="screenshot 2015-08-12 14 45 52" src="https://cloud.githubusercontent.com/assets/203725/9237620/da6c9f8c-4100-11e5-8159-f5b66b66a8b1.png">
